### PR TITLE
scratch3-qrcode v1.0 -> v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,5 @@
 
 ### scratch3-qrcode
 
+- v1.1 2020/05/13 Add error handling to TextDecoder.
 - v1.0 2020/05/12 Initial version.


### PR DESCRIPTION
QRコード内の文字コードの特定が失敗/意図しないものであった場合、マルチバイト文字のデコードが失敗して停止することを修正したv1.1を作りました。再デプロイをお願いします。