### PR TITLE
scratch3-qrcode v1.1 -> v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@
 - 0.4.3 2020/03/20 Improve Connect function
 
 ### scratch3-qrcode
-
+- v1.2 2020/05/14 Add UTF-16 decoder.
 - v1.1 2020/05/13 Add error handling to TextDecoder.
 - v1.0 2020/05/12 Initial version.


### PR DESCRIPTION
連日申し訳ございません。
ほとんどないのですが、たまにUTF16のエンコードがあるので、デコードする処理を追加して、scratch3-qrcodeをv1.2にしました。