### PR TITLE
scratch3-qrcode v1.2 -> v1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - 0.4.3 2020/03/20 Improve Connect function
 
 ### scratch3-qrcode
+- v1.3 2020/05/15 Fix font-size of credit.
 - v1.2 2020/05/14 Add UTF-16 decoder.
 - v1.1 2020/05/13 Add error handling to TextDecoder.
 - v1.0 2020/05/12 Initial version.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - 0.4.3 2020/03/20 Improve Connect function
 
 ### scratch3-qrcode
+- v1.4 2020/05/18 Fix null character issue in binary data.
 - v1.3 2020/05/15 Fix font-size of credit.
 - v1.2 2020/05/14 Add UTF-16 decoder.
 - v1.1 2020/05/13 Add error handling to TextDecoder.


### PR DESCRIPTION
v1.3で拡張機能の一覧画面の商標登録に関する表示をデンソーウェーブの指示にしたがって書き換えました。
v1.4でアクセス解析用の隠しデータ（NULL文字以降）をカットするようにしました。

現在はv1.4が最新で、こちらでデプロイをお願いしたいです。